### PR TITLE
Change the way of adding toolbar buttons to avoid plugin conflicts

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "author": "anarion80",
   "url": "https://github.com/anarion80/siyuan-oembed",
   "version": "0.1.2",
-  "minAppVersion": "3.0.12",
+  "minAppVersion": "3.1.12",
   "backends": [
     "windows",
     "linux",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
     IMenuItemOption,
     getBackend,
 } from "siyuan";
+import {IMenuItem} from "siyuan/types";
 import "@/index.scss";
 
 import { BlockIconTemplate, createBlockIconConfig, SlashCommandTemplates, ToolbarCommandsTemplates } from "./config";
@@ -23,6 +24,11 @@ export default class OembedPlugin extends Plugin {
     private isMobile: boolean;
     init() {
         setPlugin(this);
+    }
+    
+    updateProtyleToolbar(toolbar: Array<string | IMenuItem>) {
+        toolbar.push(...Object.values(ToolbarCommandsTemplates))
+        return toolbar;
     }
 
     async onload() {
@@ -53,10 +59,6 @@ export default class OembedPlugin extends Plugin {
                 callback: template.callback,
             };
         });
-
-        this.protyleOptions = {
-            toolbar: [...builtinEditTools, ...Object.values(ToolbarCommandsTemplates)],
-        };
 
         let end = performance.now();
         logger.debug(`Loading oembed completed in ${end - start} ms`);

--- a/src/libs/const.ts
+++ b/src/libs/const.ts
@@ -92,28 +92,6 @@ export const NodeIcons = {
 export const STORAGE_NAME = "menu-config";
 export const CUSTOM_ATTRIBUTE = "custom-oembed-link";
 
-export const builtinEditTools: Array<string | IToolbarItem> = [
-    "block-ref",
-    "a",
-    "|",
-    "text",
-    "strong",
-    "em",
-    "u",
-    "s",
-    "mark",
-    "sup",
-    "sub",
-    "clear",
-    "|",
-    "code",
-    "kbd",
-    "tag",
-    "inline-math",
-    "inline-memo",
-    "|",
-];
-
 export const defaultBookmarkCardStyle = `
         .kg-card {
             font-family:


### PR DESCRIPTION
Using the following code, if there are two or more plugins want to add buttons to the toolbar, only  one plugin can add the buttons successfully while the others will fail, causing conflicts.

```
        this.protyleOptions = {
            toolbar: ["block-ref",
                "a",
                "|",
                "text",
                "strong",
                "em",
                "u",
                "s",
                "mark",
                "sup",
                "sub",
                "clear",
                "|",
                "code",
                "kbd",
                "tag",
                "inline-math",
                "inline-memo",
                "|",
                {
                    name: "insert-smail-emoji",
                    icon: "iconEmoji",
                    hotkey: "⇧⌘I",
                    tipPosition: "n",
                    tip: this.i18n.insertEmoji,
                    click(protyle: Protyle) {
                        protyle.insert("😊");
                    }
                }],
        };
```
SiYuan  will add the plugin method `updateProtyleToolbar` in v3.1.12, see https://github.com/siyuan-note/plugin-sample/issues/24
```js
import {IMenuItem} from "siyuan/types";
updateProtyleToolbar(toolbar: Array<string | IMenuItem>) {
    toolbar.push("|")
    toolbar.push({
        name: "insert-smail-emoji",
        icon: "iconEmoji",
        hotkey: "⇧⌘I",
        tipPosition: "n",
        tip: this.i18n.insertEmoji,
        click(protyle: Protyle) {
            protyle.insert("😊");
        }
    })
    return toolbar;
}

```